### PR TITLE
Fix YAML syntax errors in deploy-infra workflow

### DIFF
--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -23,7 +23,8 @@ permissions:
 jobs:
   plan:
     name: Terraform Plan
-    runs-on: ubuntu-latest    env:
+    runs-on: ubuntu-latest
+    env:
       TF_ENV: ${{ github.event.inputs.environment }}
     steps:
       - name: Checkout repository
@@ -50,9 +51,7 @@ jobs:
         run: terraform -chdir=terraform/environments/${{ env.TF_ENV }} init
 
       - name: Terraform Plan
-        run: terraform -chdir=terraform/environments/${{ env.TF_ENV }} plan -out=tfplan -var-file=${{ env.TF_ENV }}.tfvars
-
-      - name: Upload plan artifact
+        run: terraform -chdir=terraform/environments/${{ env.TF_ENV }} plan -out=tfplan -var-file=${{ env.TF_ENV }}.tfvars      - name: Upload plan artifact
         uses: actions/upload-artifact@v4
         with:
           name: tfplan-${{ github.event.inputs.environment }}
@@ -61,7 +60,8 @@ jobs:
   apply:
     name: Terraform Apply
     runs-on: ubuntu-latest
-    needs: plan 
+    needs: plan
+    env:
       TF_ENV: ${{ github.event.inputs.environment }}
     steps:
       - name: Checkout repository


### PR DESCRIPTION
- Add missing newline between runs-on and env in plan job
- Add missing env: keyword in apply job
- Add missing newline between jobs: and plan:
- Add missing newline between plan and apply jobs