### PR TITLE
Fix Lambda auto-confirmation function for email alias setup

### DIFF
--- a/terraform/modules/cognito-user-management/auto_confirm_user.py
+++ b/terraform/modules/cognito-user-management/auto_confirm_user.py
@@ -11,11 +11,12 @@ def handler(event, context):
     print(f"Pre-sign-up trigger called for user: {event.get('userName', 'unknown')}")
     print(f"Event: {json.dumps(event, indent=2)}")
     
-    # Auto-confirm the user and mark email as verified
+    # Auto-confirm the user but don't auto-verify email since we're using email as alias
     # This bypasses the need for email confirmation
     event['response']['autoConfirmUser'] = True
-    event['response']['autoVerifyEmail'] = True
+    # Don't set autoVerifyEmail when using email as alias attribute
+    # event['response']['autoVerifyEmail'] = True
     
-    print("Auto-confirming user and marking email as verified")
+    print("Auto-confirming user")
     
     return event


### PR DESCRIPTION
- Remove autoVerifyEmail setting which conflicts with email alias attributes
- Keep only autoConfirmUser to bypass email verification requirement
- This resolves the InvalidLambdaResponseException during signup