### PR TITLE
Add COGNITO_CLIENT_ID environment variable to backend

### DIFF
--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -75,9 +75,9 @@ module "backend_app" {
 
   s3_uploads_bucket_name_prefix = "${var.project_name}-${var.environment}-uploads"
   log_retention_in_days         = 30
-
   # Add this line to connect the modules:
   cognito_user_pool_id = module.cognito.user_pool_id
+  cognito_client_id    = module.cognito.user_pool_client_id
 }
 
 module "cognito" {

--- a/terraform/modules/ecs-flask-backend/main.tf
+++ b/terraform/modules/ecs-flask-backend/main.tf
@@ -42,11 +42,14 @@ resource "aws_ecs_task_definition" "flask" {
       {
         name  = "AWS_REGION" # Also good to pass the region
         value = var.aws_region
-      },
-      # --- ADD THIS NEW BLOCK ---
+      },      # --- ADD THIS NEW BLOCK ---
       {
         name  = "COGNITO_USER_POOL_ID"
         value = var.cognito_user_pool_id # Use the new input variable
+      },
+      {
+        name  = "COGNITO_CLIENT_ID"
+        value = var.cognito_client_id # Use the new input variable
       }
     ]
     logConfiguration = {

--- a/terraform/modules/ecs-flask-backend/variables.tf
+++ b/terraform/modules/ecs-flask-backend/variables.tf
@@ -59,6 +59,11 @@ variable "cognito_user_pool_id" {
   type        = string
 }
 
+variable "cognito_client_id" {
+  description = "The ID of the Cognito User Pool Client to be used by the backend."
+  type        = string
+}
+
 #---------------------------------------------------------------
 # OPTIONAL PARAMETERS: These parameters have resonable defaults.
 #---------------------------------------------------------------


### PR DESCRIPTION
- Add cognito_client_id variable to ecs-flask-backend module
- Pass cognito_client_id from dev environment to backend module
- Add COGNITO_CLIENT_ID environment variable to ECS task definition

This will fix the JWT validation issue where COGNITO_CLIENT_ID was None.