### PR TITLE
Fix SES DKIM tokens output for SSM Parameter Store

### DIFF
--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -161,8 +161,8 @@ output "ses_domain_verification_token" {
 }
 
 output "ses_dkim_tokens" {
-  description = "The SES DKIM tokens for DNS setup (empty if no custom domain)"
-  value       = module.ses_email.dkim_tokens
+  description = "The SES DKIM tokens for DNS setup (JSON string, empty array if no custom domain)"
+  value       = jsonencode(module.ses_email.dkim_tokens)
 }
 
 output "ses_from_email" {


### PR DESCRIPTION
- Convert ses_dkim_tokens list to JSON string for compatibility
- SSM Parameter Store raw output only supports strings, numbers, and booleans
- DKIM tokens will now be stored as JSON array string