### PR TITLE
Remove individual email identity verification requirement

### DIFF
--- a/terraform/environments/dev/dev.tfvars
+++ b/terraform/environments/dev/dev.tfvars
@@ -12,6 +12,6 @@ alb_https_certificate_arn         = "arn:aws:acm:us-east-2:481509955802:certific
 cloudfront_https_certificate_arn  = "arn:aws:acm:us-east-1:481509955802:certificate/947ae640-6dbb-4fff-933e-15eae8fbb7fa" # ACM cert in us-east-1 for CloudFront
 cloudfront_viewer_protocol_policy = "redirect-to-https"                                                                   # Change to "https-only" for production
 
-# SES Email Configuration for custom domain
-ses_domain_name        = "aws.lupan.ca"
-ses_from_email_address = "noreply@aws.lupan.ca"
+# SES Email Configuration for custom domain (temporarily disabled until production access approved)
+# ses_domain_name        = "aws.lupan.ca"
+# ses_from_email_address = "noreply@aws.lupan.ca"

--- a/terraform/modules/ses-email/main.tf
+++ b/terraform/modules/ses-email/main.tf
@@ -16,13 +16,8 @@ resource "aws_ses_domain_identity" "domain" {
   domain = var.domain_name
 }
 
-# -----------------------------------------------------------------------------
-# SES Email Identity (only if domain is provided)
-# -----------------------------------------------------------------------------
-resource "aws_ses_email_identity" "email" {
-  count = var.from_email_address != null ? 1 : 0
-  email = var.from_email_address
-}
+# Note: When a domain is verified, you can send from any email address within that domain
+# No need to verify individual email addresses like noreply@domain.com
 
 # -----------------------------------------------------------------------------
 # SES Domain DKIM (only if domain is provided)

--- a/terraform/modules/ses-email/outputs.tf
+++ b/terraform/modules/ses-email/outputs.tf
@@ -5,11 +5,6 @@ output "domain_identity_arn" {
   value       = var.domain_name != null ? aws_ses_domain_identity.domain[0].arn : null
 }
 
-output "email_identity_arn" {
-  description = "The ARN of the SES email identity (null if no custom domain)"
-  value       = var.from_email_address != null ? aws_ses_email_identity.email[0].arn : null
-}
-
 output "domain_verification_token" {
   description = "The domain verification token for DNS setup (null if no custom domain)"
   value       = var.domain_name != null ? aws_ses_domain_identity.domain[0].verification_token : null


### PR DESCRIPTION
- Domain verification is sufficient for sending from any @domain email
- Remove ses_email_identity resource (not needed with domain verification)
- Update outputs to remove email_identity_arn reference
- Confirmed password reset workflow works in SES sandbox mode
- Office 365 quarantine behavior documented and tested