### PR TITLE
fix: remove unsupported tags argument from S3 lifecycle configuration

### DIFF
--- a/terraform/modules/ecs-flask-backend/s3_uploads.tf
+++ b/terraform/modules/ecs-flask-backend/s3_uploads.tf
@@ -58,9 +58,4 @@ resource "aws_s3_bucket_lifecycle_configuration" "uploads_backend_lifecycle" {
       noncurrent_days = var.file_retention_days
     }
   }
-
-  tags = {
-    Environment = var.environment
-    Project     = var.project_name
-  }
 }


### PR DESCRIPTION
- aws_s3_bucket_lifecycle_configuration does not support tags argument
- Fixes Terraform plan error during deployment