### PR TITLE
feat: add Email Link feature for Premium File Explorer

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -687,6 +687,13 @@ const PremiumFileExplorer = ({ signOut, user, tier, getJwtToken }) => {
                           </Button>
                           <Button 
                             size="small" 
+                            variation="warning"
+                            onClick={() => emailLink(file.key, file.filename)}
+                          >
+                            📧 Email Link
+                          </Button>
+                          <Button 
+                            size="small" 
                             variation="destructive"
                             onClick={() => deleteFile(file.key, file.filename)}
                           >


### PR DESCRIPTION
- Add Email Link button between New Link and Delete in Premium File Explorer
- Generate mailto: URL with pre-populated subject and body
- Launch user's default email client (Outlook, Gmail, etc.)
- Include download link and professional email template
- Fix welcome message to show email instead of GUID
- Use fetchUserAttributes to get user email for display name