### PR TITLE
fix: shorten Email Link content to avoid mailto URL length limits

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -861,19 +861,14 @@ const AppContent = ({ user, signOut }) => {
   const handleEmailLink = (downloadUrl) => {
     console.log('Email Link clicked for URL:', downloadUrl);
     
-    const subject = encodeURIComponent('File Download Link - FileShare Plus');
+    const subject = encodeURIComponent('File shared with you - FileShare Plus');
     const body = encodeURIComponent(`Hi there!
 
-I've shared a file with you through FileShare Plus. You can download it using the link below:
+I've shared a file with you. Please copy and paste this download link in your browser:
 
 ${downloadUrl}
 
-This is a secure download link that will allow you to access the file directly.
-
-Best regards!
-
----
-Powered by FileShare Plus - Secure file sharing made simple`);
+Best regards!`);
 
     const mailtoUrl = `mailto:?subject=${subject}&body=${body}`;
     console.log('Generated mailto URL:', mailtoUrl);


### PR DESCRIPTION
- Reduce email body text to essential information only
- Remove marketing text and extra formatting
- Keep URL under 2000 character limit for better compatibility
- Test mailto button confirmed Windows/Outlook work fine with shorter URLs