### PR TITLE
🔗 Route short URLs through CloudFront instead of direct ALB access

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -272,8 +272,8 @@ def get_download_link(decoded_token):
             expires_in_days=expiration_seconds // 86400  # Convert seconds to days
         )
         
-        # Build short URL
-        base_url = request.host_url.rstrip('/')
+        # Build short URL using CloudFront domain
+        base_url = get_short_url_base()
         short_url = f"{base_url}/s/{short_url_result['short_code']}"
         
         return jsonify({
@@ -466,8 +466,8 @@ def generate_new_download_link(decoded_token):
             expires_in_days=expiration_seconds // 86400  # Convert seconds to days
         )
         
-        # Build short URL
-        base_url = request.host_url.rstrip('/')
+        # Build short URL using CloudFront domain
+        base_url = get_short_url_base()
         short_url = f"{base_url}/s/{short_url_result['short_code']}"
         
         print(f"Generated new short URL for: {file_key}")
@@ -556,8 +556,8 @@ def shorten_url(decoded_token):
             expires_in_days=expires_in_days
         )
         
-        # Build short URL
-        base_url = request.host_url.rstrip('/')
+        # Build short URL using CloudFront domain
+        base_url = get_short_url_base()
         short_url = f"{base_url}/s/{result['short_code']}"
         
         return jsonify({
@@ -641,6 +641,16 @@ def delete_short_url_endpoint(decoded_token, short_code):
         print(f"Error deleting short URL {short_code}: {e}")
         return jsonify({'message': f'Error deleting short URL: {e}'}), 500
 
+
+def get_short_url_base():
+    """Get the base URL for constructing short URLs (prefer CloudFront domain)"""
+    frontend_domain = os.getenv('FRONTEND_DOMAIN')
+    if frontend_domain:
+        # Use CloudFront domain for short URLs
+        return f"https://{frontend_domain}"
+    else:
+        # Fallback to ALB domain (for local development)
+        return request.host_url.rstrip('/')
 
 if __name__ == "__main__":
     app.run(debug=True, host='0.0.0.0', port=5000)

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -81,6 +81,9 @@ module "backend_app" {
 
   # Configure file retention period for S3 lifecycle policy
   file_retention_days = var.file_retention_days
+  
+  # Pass CloudFront domain for short URL construction
+  frontend_domain = var.cloudfront_custom_domain_name != "" ? var.cloudfront_custom_domain_name : module.frontend_app.cloudfront_domain_name
 }
 
 module "cognito" {

--- a/terraform/modules/ecs-flask-backend/main.tf
+++ b/terraform/modules/ecs-flask-backend/main.tf
@@ -50,6 +50,10 @@ resource "aws_ecs_task_definition" "flask" {
       {
         name  = "COGNITO_CLIENT_ID"
         value = var.cognito_client_id # Use the new input variable
+      },
+      {
+        name  = "FRONTEND_DOMAIN"
+        value = var.frontend_domain # CloudFront domain for short URL construction
       }
     ]
     logConfiguration = {

--- a/terraform/modules/ecs-flask-backend/variables.tf
+++ b/terraform/modules/ecs-flask-backend/variables.tf
@@ -64,6 +64,12 @@ variable "cognito_client_id" {
   type        = string
 }
 
+variable "frontend_domain" {
+  description = "The CloudFront domain name for the frontend (used for constructing short URLs)"
+  type        = string
+  default     = ""
+}
+
 #---------------------------------------------------------------
 # OPTIONAL PARAMETERS: These parameters have resonable defaults.
 #---------------------------------------------------------------


### PR DESCRIPTION
Infrastructure Changes:
- Added CloudFront cache behavior for /s/* paths to route to ALB
- Added FRONTEND_DOMAIN environment variable to ECS backend
- Pass CloudFront domain from main.tf to backend module

Backend Changes:
- Added get_short_url_base() helper function
- Updated all short URL construction to use CloudFront domain
- Fallback to ALB domain for local development

Benefits:
- Short URLs now use cf.aws.lupan.ca instead of alb.aws.lupan.ca
- Maintains proper CloudFront -> ALB traffic flow
- Enables ALB access restriction to CloudFront only (future enhancement)
- Better performance with CloudFront caching for short URL redirects