### PR TITLE
🔧 Fix frontend API URL to use CloudFront instead of direct ALB

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -72,7 +72,7 @@ jobs:
           VITE_USER_POOL_ID: ${{ env.USER_POOL_ID }}
           VITE_USER_POOL_CLIENT_ID: ${{ env.USER_POOL_CLIENT_ID }}
           VITE_CLOUDFRONT_CUSTOM_DOMAIN_URL: ${{ env.CLOUDFRONT_CUSTOM_DOMAIN_URL }}
-          VITE_BACKEND_API_URL: ${{ env.BACKEND_ALB_URL }}
+          VITE_BACKEND_API_URL: ${{ env.CLOUDFRONT_CUSTOM_DOMAIN_URL }}
           
       - name: Deploy static site to S3
         run: |


### PR DESCRIPTION
- Changed VITE_BACKEND_API_URL from BACKEND_ALB_URL to CLOUDFRONT_CUSTOM_DOMAIN_URL
- This resolves CORS errors caused by bypassing CloudFront
- All API calls now properly flow through CloudFront → ALB instead of direct ALB access
- Maintains the intended architecture where all traffic goes through CloudFront