### PR TITLE
Fix CloudFront Authorization header forwarding for JWT tokens

### DIFF
--- a/terraform/modules/s3-cloudfront-frontend/main.tf
+++ b/terraform/modules/s3-cloudfront-frontend/main.tf
@@ -64,7 +64,7 @@ resource "aws_cloudfront_distribution" "this" {
     # This is crucial for POST requests, CORS, and any session handling
     forwarded_values {
       query_string = true
-      headers      = ["Origin", "Access-Control-Request-Headers", "Access-Control-Request-Method", "Host"] # Host header is important for ALB routing
+      headers      = ["Origin", "Access-Control-Request-Headers", "Access-Control-Request-Method", "Host", "Authorization"] # Added Authorization for JWT tokens
       cookies {
         forward = "all"
       }


### PR DESCRIPTION
- Add 'Authorization' header to forwarded headers list in /api/* cache behavior
- This fixes the issue where JWT tokens were not being forwarded to backend
- Upload requests (POST) were working but download link requests (GET) were failing
- Backend logs showed 'Authorization header: NOT FOUND' for GET requests
- Root cause: CloudFront was not forwarding Authorization header for API requests
- This should fix both Free and Premium tier 'Token is missing!' errors