### PR TITLE
fix: restore 3-day auto-link generation for Premium uploads

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -512,9 +512,9 @@ const PremiumFileExplorer = ({ signOut, user, tier, getJwtToken }) => {
       setFile(null);
       
       // Auto-generate a 3-day link for Premium uploads
-      if (uploadData.file_key) {
+      if (uploadData.file_name) {
         try {
-          await generateNewLink(uploadData.file_key, 3);
+          await generateNewLink(uploadData.file_name, 3);
         } catch (linkError) {
           console.error('Error auto-generating link:', linkError);
           setMessage('File uploaded successfully! (Link generation failed - you can create one manually)');


### PR DESCRIPTION
- Backend returns 'file_name' but frontend was expecting 'file_key'
- Updated frontend to use uploadData.file_name for auto-link generation
- Premium uploads should now automatically get 3-day download links again
- Fixes regression from Phase 1 backend integration